### PR TITLE
chore(dependabot): add github-actions update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,16 @@ updates:
       major-revisions:
         update-types:
           - major
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      non-major-revisions:
+        update-types:
+          - minor
+          - patch
+      major-revisions:
+        update-types:
+          - major


### PR DESCRIPTION
Adds github-actions to the dependabot configuration. It updates on a weekly schedule from the root directory and groups non-major/major revisions in the same way as the npm ecosystem configuration.

---
*PR created automatically by Jules for task [6466515007534987309](https://jules.google.com/task/6466515007534987309) started by @BayanBennett*