### PR TITLE
chore: use @tsconfig/next for tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@tsconfig/next": "^2.0.6",
     "@workos-inc/authkit-nextjs": "^4.1.0",
     "convex": "^1.39.1",
     "next": "^16.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tsconfig/next':
+        specifier: ^2.0.6
+        version: 2.0.6
       '@workos-inc/authkit-nextjs':
         specifier: ^4.1.0
         version: 4.1.0(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
@@ -894,6 +897,9 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@tsconfig/next@2.0.6':
+    resolution: {integrity: sha512-C6eZoNyAMKv2UvzDZqcp8zXPviu6W4Ev1KUbqfmaMSZuq+tmbtTWaqxTif/yaui8WCEcRlQrHC8q9tNzBclHOw==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -3449,6 +3455,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
+  '@tsconfig/next@2.0.6': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,9 @@
 {
+  "extends": "@tsconfig/next/tsconfig.json",
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
     "types": ["vite/client"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "react-jsx",
-    "incremental": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
This commit adds `@tsconfig/next` as a regular dependency using pnpm. The local `tsconfig.json` has been updated to extend `@tsconfig/next/tsconfig.json`, deferring standard configurations to the base config. We kept path aliases, custom types like `vite/client`, and specific `compilerOptions` customizations per the project's requirements. Tests and type checks have been run to verify the configuration change.

---
*PR created automatically by Jules for task [5007933480055779900](https://jules.google.com/task/5007933480055779900) started by @BayanBennett*