### PR TITLE
feat: replace inline svg with lucide-react icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tsconfig/next": "^2.0.6",
     "@workos-inc/authkit-nextjs": "^4.1.0",
     "convex": "^1.39.1",
+    "lucide-react": "^1.16.0",
     "next": "^16.2.6",
     "react": "19.2.6",
     "react-dom": "19.2.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       convex:
         specifier: ^1.39.1
         version: 1.39.1(react@19.2.6)
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2116,6 +2119,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -4839,6 +4847,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.16.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   lz-string@1.5.0: {}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Check } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
@@ -123,9 +124,7 @@ export default function Home() {
                     className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-zinc-300 dark:border-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors"
                     aria-label="Complete task"
                   >
-                    <svg className="w-4 h-4 text-transparent hover:text-green-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
-                    </svg>
+                    <Check className="w-4 h-4 text-transparent hover:text-green-500 transition-colors" strokeWidth={3} />
                   </button>
                 </li>
               ))}


### PR DESCRIPTION
Added `lucide-react` as a dependency and replaced the inline SVG check icon in `src/app/page.tsx` with the equivalent `Check` icon from `lucide-react`. The icon retains all the original Tailwind classes and styling.

Tests and build process passed successfully.

---
*PR created automatically by Jules for task [9205861980831534880](https://jules.google.com/task/9205861980831534880) started by @BayanBennett*