### PR TITLE
🧪 [testing improvement description]

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -46,4 +46,37 @@ describe("tasks", () => {
     // Check organization was created/linked
     expect(user?.orgId).toBeDefined();
   });
+
+  it("should update user orgId when synced with a different org", async () => {
+    const modules = import.meta.glob("./**/*.*s");
+    const t = convexTest(schema, modules);
+
+    // Action 1: Sync user with first org
+    // @ts-expect-error - vitest environment
+    await t.mutation(syncUser, {
+        tokenIdentifier: "user_multi_org",
+        workosOrgId: "org_first",
+    });
+
+    // Validation 1: Get user and store first orgId
+    // @ts-expect-error - vitest environment
+    const user1 = await t.query(getUser, { tokenIdentifier: "user_multi_org" });
+    expect(user1).not.toBeNull();
+    const firstOrgId = user1?.orgId;
+    expect(firstOrgId).toBeDefined();
+
+    // Action 2: Sync same user with second org
+    // @ts-expect-error - vitest environment
+    await t.mutation(syncUser, {
+        tokenIdentifier: "user_multi_org",
+        workosOrgId: "org_second",
+    });
+
+    // Validation 2: Get user again and verify orgId changed
+    // @ts-expect-error - vitest environment
+    const user2 = await t.query(getUser, { tokenIdentifier: "user_multi_org" });
+    expect(user2).not.toBeNull();
+    expect(user2?.orgId).toBeDefined();
+    expect(user2?.orgId).not.toBe(firstOrgId);
+  });
 });


### PR DESCRIPTION
* 🎯 **What:** The testing gap addressed: Missing test for user orgId update when a user switches organizations (in `convex/functions.ts:82`).
* 📊 **Coverage:** Covered the scenario where an existing user's `workosOrgId` changes, verifying that the `orgId` maps to the new organization correctly.
* ✨ **Result:** The test suite now reliably ensures user organization syncing handles updates.

---
*PR created automatically by Jules for task [17547561824617590542](https://jules.google.com/task/17547561824617590542) started by @BayanBennett*