### PR TITLE
🔒 Fix IDOR vulnerability in listTasks query

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -11,6 +11,7 @@ describe("tasks", () => {
     // Setup: Create a test organization and user
     // @ts-expect-error - vitest environment
     const orgId = await t.mutation(testSetupOrg, { workosOrgId: "org_123", billingTier: "pro" });
+    const userAuth = t.withIdentity({ tokenIdentifier: "user_123" });
     // @ts-expect-error - vitest environment
     const userId = await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });
 
@@ -20,7 +21,7 @@ describe("tasks", () => {
 
     // Validation: List tasks
     // @ts-expect-error - vitest environment
-    const tasks = await t.query(listTasks, { orgId });
+    const tasks = await userAuth.query(listTasks, { orgId });
     expect(tasks).toHaveLength(1);
     expect(tasks[0].rawCapture).toBe("Test task");
     expect(tasks[0].status).toBe("active");

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -4,6 +4,17 @@ import { v } from "convex/values";
 export const listTasks = query({
   args: { orgId: v.id("organizations") },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthenticated");
+    }
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
+      .unique();
+    if (!user || user.orgId !== args.orgId) {
+      throw new Error("Unauthorized");
+    }
     return await ctx.db
       .query("tasks")
       .withIndex("by_orgId", (q) => q.eq("orgId", args.orgId))


### PR DESCRIPTION
🎯 **What:** Fixed an Insecure Direct Object Reference (IDOR) vulnerability in the `listTasks` query.
⚠️ **Risk:** Before this fix, any user could query tasks belonging to any organization simply by providing the organization's `orgId`. This could lead to a massive data breach if malicious actors scraped tasks by enumerating `orgId`s.
🛡️ **Solution:** The query now requires the user to be authenticated and ensures the authenticated user's `orgId` matches the requested `orgId` before returning any tasks. Unauthenticated users receive an "Unauthenticated" error, and users requesting tasks outside of their organization receive an "Unauthorized" error.

---
*PR created automatically by Jules for task [2422149603044133018](https://jules.google.com/task/2422149603044133018) started by @BayanBennett*