### PR TITLE
🔒 fix(convex): use internalMutation for test setup endpoints

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -1,4 +1,4 @@
-import { query, mutation } from "./_generated/server";
+import { query, mutation, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 export const listTasks = query({
@@ -31,7 +31,7 @@ export const createTask = mutation({
   },
 });
 
-export const testSetupOrg = mutation({
+export const testSetupOrg = internalMutation({
   args: { workosOrgId: v.string(), billingTier: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db.insert("organizations", {
@@ -41,7 +41,7 @@ export const testSetupOrg = mutation({
   },
 });
 
-export const testSetupUser = mutation({
+export const testSetupUser = internalMutation({
   args: { tokenIdentifier: v.string(), orgId: v.id("organizations"), role: v.string() },
   handler: async (ctx, args) => {
     return await ctx.db.insert("users", {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `testSetupOrg` and `testSetupUser` mutations were exposed to the public API by using `mutation(...)`. 

⚠️ **Risk:** The potential impact if left unfixed
This allowed any unauthenticated user in production to execute these setup functions and create arbitrary organizations and users, bypassing application logic and filling the database with garbage data or potentially gaining unauthorized access (by giving themselves admin roles).

🛡️ **Solution:** How the fix addresses the vulnerability
Changed the endpoints from `mutation` to `internalMutation`. This restricts them from public access, ensuring they can only be invoked by internal Convex functions or by tests via `convexTest`, thus securing production.

---
*PR created automatically by Jules for task [1406496326958757754](https://jules.google.com/task/1406496326958757754) started by @BayanBennett*