### PR TITLE
🔒 Fix IDOR vulnerability in createTask

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -4,6 +4,15 @@ import schema from "./schema";
 import { listTasks, createTask, testSetupOrg, testSetupUser, syncUser, getUser } from "./functions";
 
 describe("tasks", () => {
+  it("should throw an error when creating a task unauthenticated", async () => {
+    const modules = import.meta.glob("./**/*.*s");
+    const t = convexTest(schema, modules);
+
+    // Action: Create a task without identity
+    // @ts-expect-error - vitest environment
+    await expect(t.mutation(createTask, { rawCapture: "Test task" })).rejects.toThrow("Unauthenticated call to createTask");
+  });
+
   it("should create and list tasks", async () => {
     const modules = import.meta.glob("./**/*.*s");
     const t = convexTest(schema, modules);
@@ -12,11 +21,12 @@ describe("tasks", () => {
     // @ts-expect-error - vitest environment
     const orgId = await t.mutation(testSetupOrg, { workosOrgId: "org_123", billingTier: "pro" });
     // @ts-expect-error - vitest environment
-    const userId = await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });
+    await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });
 
     // Action: Create a task
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_123" });
     // @ts-expect-error - vitest environment
-    await t.mutation(createTask, { orgId, userId, rawCapture: "Test task" });
+    await tWithIdentity.mutation(createTask, { rawCapture: "Test task" });
 
     // Validation: List tasks
     // @ts-expect-error - vitest environment

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -13,14 +13,26 @@ export const listTasks = query({
 
 export const createTask = mutation({
   args: {
-    orgId: v.id("organizations"),
-    userId: v.id("users"),
     rawCapture: v.string(),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthenticated call to createTask");
+    }
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
+      .unique();
+
+    if (!user) {
+      throw new Error("User not found");
+    }
+
     const taskId = await ctx.db.insert("tasks", {
-      orgId: args.orgId,
-      userId: args.userId,
+      orgId: user.orgId,
+      userId: user._id,
       rawCapture: args.rawCapture,
       status: "active", // Updated to default to active for self-captured tasks as per spec,
       eisenhowerQuadrant: 2, // Default to Important/Not Urgent

--- a/patch_createTask.py
+++ b/patch_createTask.py
@@ -3,10 +3,63 @@ import re
 with open('convex/functions.ts', 'r') as f:
     content = f.read()
 
-# Update status: "inbox" to status: "active"
-new_content = re.sub(r'status:\s*"inbox"', 'status: "active", // Updated to default to active for self-captured tasks as per spec', content)
+# Replace createTask
+old_createTask = """export const createTask = mutation({
+  args: {
+    orgId: v.id("organizations"),
+    userId: v.id("users"),
+    rawCapture: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const taskId = await ctx.db.insert("tasks", {
+      orgId: args.orgId,
+      userId: args.userId,
+      rawCapture: args.rawCapture,
+      status: "active", // Updated to default to active for self-captured tasks as per spec,
+      eisenhowerQuadrant: 2, // Default to Important/Not Urgent
+      bentoSize: "medium",
+      energyRequired: 5,
+    });
+    return taskId;
+  },
+});"""
 
-with open('convex/functions.ts', 'w') as f:
-    f.write(new_content)
+new_createTask = """export const createTask = mutation({
+  args: {
+    rawCapture: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthenticated call to createTask");
+    }
 
-print("Updated functions.ts")
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
+      .unique();
+
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const taskId = await ctx.db.insert("tasks", {
+      orgId: user.orgId,
+      userId: user._id,
+      rawCapture: args.rawCapture,
+      status: "active", // Updated to default to active for self-captured tasks as per spec,
+      eisenhowerQuadrant: 2, // Default to Important/Not Urgent
+      bentoSize: "medium",
+      energyRequired: 5,
+    });
+    return taskId;
+  },
+});"""
+
+if old_createTask in content:
+    content = content.replace(old_createTask, new_createTask)
+    with open('convex/functions.ts', 'w') as f:
+        f.write(content)
+    print("Updated functions.ts")
+else:
+    print("Could not find old createTask")

--- a/patch_page.py
+++ b/patch_page.py
@@ -3,67 +3,53 @@ import re
 with open('src/app/page.tsx', 'r') as f:
     content = f.read()
 
-# 1. Add completeTask mutation
-content = content.replace('const createTask = useMutation(api.functions.createTask);', 'const createTask = useMutation(api.functions.createTask);\n  const completeTask = useMutation((api.functions as unknown as { completeTask: import("convex/server").FunctionReference<"mutation"> }).completeTask);')
+# Replace handleCapture
+old_handleCapture = """  const handleCapture = async () => {
+    // If not using real auth yet, allow submission even if user isn't loaded completely
+    // Let convex test setup handle the rest if mock user isn't ready
+    if (!captureText.trim()) return;
 
-# 2. Add listTasks query
-content = content.replace("""  // Mock user handling: sync a test user to get their user ID and org ID
-  const syncUser = useMutation(api.functions.syncUser);
-  const user = useQuery(api.functions.getUser, { tokenIdentifier: "mock-user-123" });""", """  // Mock user handling: sync a test user to get their user ID and org ID
-  const syncUser = useMutation(api.functions.syncUser);
-  const user = useQuery(api.functions.getUser, { tokenIdentifier: "mock-user-123" });
-
-  // Query active tasks
-  const tasks = useQuery(api.functions.listTasks, user ? { orgId: user.orgId } : "skip");
-  const activeTasks = tasks?.filter((task: { status: string; _id: string; rawCapture: string }) => task.status === "active") ?? [];""")
-
-# 3. Add handleComplete function
-handle_complete_func = """
-  const handleComplete = async (taskId: string) => {
+    setIsSubmitting(true);
     try {
-      await completeTask({ taskId });
+      if (user) {
+        await createTask({
+          orgId: user.orgId,
+          userId: user._id,
+          rawCapture: captureText.trim(),
+        });
+        setCaptureText("");
+      }
     } catch (error) {
-      console.error("Failed to complete task", error);
+      console.error("Failed to create task", error);
+    } finally {
+      setIsSubmitting(false);
     }
-  };
-"""
-content = content.replace('const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {', handle_complete_func + '\n  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {')
+  };"""
 
-# 4. Add the section to display active tasks
-tasks_section = """
-        {activeTasks.length > 0 && (
-          <section className="bg-white dark:bg-zinc-900 rounded-2xl p-6 shadow-sm border border-zinc-200 dark:border-zinc-800 flex flex-col gap-4">
-            <h2 className="text-xl font-semibold text-zinc-800 dark:text-zinc-200">
-              Active Focus
-            </h2>
-            <ul className="flex flex-col gap-3">
-              {activeTasks.map((task) => (
-                <li
-                  key={task._id}
-                  className="flex items-center justify-between bg-zinc-50 dark:bg-zinc-800/50 p-4 rounded-xl border border-zinc-100 dark:border-zinc-800/80"
-                >
-                  <span className="text-zinc-800 dark:text-zinc-200 text-lg">
-                    {task.rawCapture}
-                  </span>
-                  <button
-                    onClick={() => handleComplete(task._id)}
-                    className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-zinc-300 dark:border-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-700 transition-colors"
-                    aria-label="Complete task"
-                  >
-                    <svg className="w-4 h-4 text-transparent hover:text-green-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
-                    </svg>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
-"""
+new_handleCapture = """  const handleCapture = async () => {
+    // If not using real auth yet, allow submission even if user isn't loaded completely
+    // Let convex test setup handle the rest if mock user isn't ready
+    if (!captureText.trim()) return;
 
-content = content.replace('</section>\n\n        <footer', '</section>\n' + tasks_section + '\n        <footer')
+    setIsSubmitting(true);
+    try {
+      if (user) {
+        await createTask({
+          rawCapture: captureText.trim(),
+        });
+        setCaptureText("");
+      }
+    } catch (error) {
+      console.error("Failed to create task", error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };"""
 
-with open('src/app/page.tsx', 'w') as f:
-    f.write(content)
-
-print("Updated page.tsx")
+if old_handleCapture in content:
+    content = content.replace(old_handleCapture, new_handleCapture)
+    with open('src/app/page.tsx', 'w') as f:
+        f.write(content)
+    print("Updated page.tsx")
+else:
+    print("Could not find old handleCapture")

--- a/patch_test.py
+++ b/patch_test.py
@@ -1,0 +1,58 @@
+import re
+
+with open('convex/functions.test.ts', 'r') as f:
+    content = f.read()
+
+# Replace createTask call
+old_test = """  it("should create and list tasks", async () => {
+    const modules = import.meta.glob("./**/*.*s");
+    const t = convexTest(schema, modules);
+
+    // Setup: Create a test organization and user
+    // @ts-expect-error - vitest environment
+    const orgId = await t.mutation(testSetupOrg, { workosOrgId: "org_123", billingTier: "pro" });
+    // @ts-expect-error - vitest environment
+    const userId = await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });
+
+    // Action: Create a task
+    // @ts-expect-error - vitest environment
+    await t.mutation(createTask, { orgId, userId, rawCapture: "Test task" });
+
+    // Validation: List tasks
+    // @ts-expect-error - vitest environment
+    const tasks = await t.query(listTasks, { orgId });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].rawCapture).toBe("Test task");
+    expect(tasks[0].status).toBe("active");
+  });"""
+
+new_test = """  it("should create and list tasks", async () => {
+    const modules = import.meta.glob("./**/*.*s");
+    const t = convexTest(schema, modules);
+
+    // Setup: Create a test organization and user
+    // @ts-expect-error - vitest environment
+    const orgId = await t.mutation(testSetupOrg, { workosOrgId: "org_123", billingTier: "pro" });
+    // @ts-expect-error - vitest environment
+    const userId = await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });
+
+    // Action: Create a task
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_123" });
+    // @ts-expect-error - vitest environment
+    await tWithIdentity.mutation(createTask, { rawCapture: "Test task" });
+
+    // Validation: List tasks
+    // @ts-expect-error - vitest environment
+    const tasks = await t.query(listTasks, { orgId });
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].rawCapture).toBe("Test task");
+    expect(tasks[0].status).toBe("active");
+  });"""
+
+if old_test in content:
+    content = content.replace(old_test, new_test)
+    with open('convex/functions.test.ts', 'w') as f:
+        f.write(content)
+    print("Updated functions.test.ts")
+else:
+    print("Could not find old test")

--- a/patch_test2.py
+++ b/patch_test2.py
@@ -1,0 +1,26 @@
+import re
+
+with open('convex/functions.test.ts', 'r') as f:
+    content = f.read()
+
+# Add unauthenticated test
+old_test = """  it("should create and list tasks", async () => {"""
+
+new_test = """  it("should throw an error when creating a task unauthenticated", async () => {
+    const modules = import.meta.glob("./**/*.*s");
+    const t = convexTest(schema, modules);
+
+    // Action: Create a task without identity
+    // @ts-expect-error - vitest environment
+    await expect(t.mutation(createTask, { rawCapture: "Test task" })).rejects.toThrow("Unauthenticated call to createTask");
+  });
+
+  it("should create and list tasks", async () => {"""
+
+if old_test in content:
+    content = content.replace(old_test, new_test)
+    with open('convex/functions.test.ts', 'w') as f:
+        f.write(content)
+    print("Updated functions.test.ts")
+else:
+    print("Could not find old test")

--- a/patch_test_lint.py
+++ b/patch_test_lint.py
@@ -1,0 +1,25 @@
+import re
+
+with open('convex/functions.test.ts', 'r') as f:
+    content = f.read()
+
+# Remove unused userId
+old_test = """    // Setup: Create a test organization and user
+    // @ts-expect-error - vitest environment
+    const orgId = await t.mutation(testSetupOrg, { workosOrgId: "org_123", billingTier: "pro" });
+    // @ts-expect-error - vitest environment
+    const userId = await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });"""
+
+new_test = """    // Setup: Create a test organization and user
+    // @ts-expect-error - vitest environment
+    const orgId = await t.mutation(testSetupOrg, { workosOrgId: "org_123", billingTier: "pro" });
+    // @ts-expect-error - vitest environment
+    await t.mutation(testSetupUser, { tokenIdentifier: "user_123", orgId, role: "admin" });"""
+
+if old_test in content:
+    content = content.replace(old_test, new_test)
+    with open('convex/functions.test.ts', 'w') as f:
+        f.write(content)
+    print("Updated functions.test.ts")
+else:
+    print("Could not find old test")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,8 +39,6 @@ export default function Home() {
     try {
       if (user) {
         await createTask({
-          orgId: user.orgId,
-          userId: user._id,
           rawCapture: captureText.trim(),
         });
         setCaptureText("");


### PR DESCRIPTION
🎯 **What:** Fixed an Insecure Direct Object Reference (IDOR) vulnerability in the `createTask` mutation where a user could potentially supply an arbitrary `userId` and `orgId`.

⚠️ **Risk:** If left unfixed, malicious users could create tasks on behalf of other users or organizations by passing arbitrary user IDs and organization IDs to the mutation arguments, potentially leading to unauthorized data creation.

🛡️ **Solution:** Removed `userId` and `orgId` arguments from the `createTask` mutation. Instead, securely obtained the user's identity from the request context using `ctx.auth.getUserIdentity()`, and fetched the corresponding user and organization IDs server-side to guarantee authenticity. Also updated the frontend calling code and test cases.

---
*PR created automatically by Jules for task [1843094770702466459](https://jules.google.com/task/1843094770702466459) started by @BayanBennett*