### PR TITLE
🧹 Remove leftover lint patch script

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -49,7 +49,6 @@ describe("tasks", () => {
     });
 
     // Validation: Get user
-    // @ts-expect-error - vitest environment
     const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_abc" });
     // @ts-expect-error - vitest environment
     const user = await tWithIdentity.query(getUser, { tokenIdentifier: "user_abc" });
@@ -72,7 +71,6 @@ describe("tasks", () => {
     });
 
     // Validation 1: Get user and store first orgId
-    // @ts-expect-error - vitest environment
     const tWithIdentity1 = t.withIdentity({ tokenIdentifier: "user_multi_org" });
     // @ts-expect-error - vitest environment
     const user1 = await tWithIdentity1.query(getUser, { tokenIdentifier: "user_multi_org" });
@@ -88,7 +86,6 @@ describe("tasks", () => {
     });
 
     // Validation 2: Get user again and verify orgId changed
-    // @ts-expect-error - vitest environment
     const tWithIdentity2 = t.withIdentity({ tokenIdentifier: "user_multi_org" });
     // @ts-expect-error - vitest environment
     const user2 = await tWithIdentity2.query(getUser, { tokenIdentifier: "user_multi_org" });
@@ -108,7 +105,6 @@ describe("tasks", () => {
     });
 
     // Validation: Get user
-    // @ts-expect-error - vitest environment
     const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_personal" });
     // @ts-expect-error - vitest environment
     const user = await tWithIdentity.query(getUser, { tokenIdentifier: "user_personal" });

--- a/patch_functions_lint.py
+++ b/patch_functions_lint.py
@@ -1,9 +1,0 @@
-import re
-
-with open('convex/functions.ts', 'r') as f:
-    content = f.read()
-
-content = content.replace('let user = await ctx.db', 'const user = await ctx.db')
-
-with open('convex/functions.ts', 'w') as f:
-    f.write(content)


### PR DESCRIPTION
🎯 What: Removed patch_functions_lint.py and fixed the linting issues that popped up in tests.
💡 Why: Similar to other patch scripts, this is a one-off utility that clutters the workspace and should be removed.
✅ Verification: Ran test suite, typechecking, and linting suite. All passed with zero errors or warnings.
✨ Result: Maintained a clutter-free root directory, reducing technical debt.

---
*PR created automatically by Jules for task [2008934512096843492](https://jules.google.com/task/2008934512096843492) started by @BayanBennett*