### PR TITLE
🧪 Add test file for sign-in route

### DIFF
--- a/src/app/sign-in/route.test.ts
+++ b/src/app/sign-in/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from './route';
+import { getSignInUrl } from '@workos-inc/authkit-nextjs';
+import { redirect } from 'next/navigation';
+
+vi.mock('@workos-inc/authkit-nextjs', () => ({
+  getSignInUrl: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(),
+}));
+
+describe('Sign In API Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should redirect to the sign in url on success', async () => {
+    const mockUrl = 'https://example.com/sign-in';
+    vi.mocked(getSignInUrl).mockResolvedValue(mockUrl);
+    // @ts-expect-error - vitest environment mocking redirect response
+    vi.mocked(redirect).mockReturnValue('mock-redirect-response');
+
+    const response = await GET();
+
+    expect(getSignInUrl).toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith(mockUrl);
+    expect(response).toBe('mock-redirect-response');
+  });
+
+  it('should propagate errors from getSignInUrl', async () => {
+    const mockError = new Error('Failed to generate sign-in URL');
+    vi.mocked(getSignInUrl).mockRejectedValue(mockError);
+
+    await expect(GET()).rejects.toThrow('Failed to generate sign-in URL');
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The sign-in route lacked a test file to verify its logic.
📊 **Coverage:** Added coverage for the happy path and error scenarios when getSignInUrl fails to resolve.
✨ **Result:** Improved test coverage and reliability of the authentication flow.

---
*PR created automatically by Jules for task [3912017518008365122](https://jules.google.com/task/3912017518008365122) started by @BayanBennett*