### PR TITLE
🧪 Add test for completing a non-existent task

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -196,4 +196,18 @@ describe("tasks", () => {
     expect(tasks).toHaveLength(1);
     expect(tasks[0].status).toBe("completed");
   });
+
+  it("should throw an error when completing a non-existent task", async () => {
+    const t = initTest();
+
+    // Setup: Create an org and user
+    await setupUserAndOrg(t, "user_nonexistent", "org_nonexistent");
+
+    // Action: Try to complete a task that doesn't exist using a syntactically valid ID format
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_nonexistent" });
+    const fakeId = "jd10wtp2eb15a2h7z1s7c0b050m7";
+    // @ts-expect-error - vitest environment
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(tWithIdentity.mutation(completeTask, { taskId: fakeId as any })).rejects.toThrow("Task not found");
+  });
 });


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `convex/functions.test.ts` for the `completeTask` mutation to handle scenarios where a non-existent task ID is provided.
📊 **Coverage:** Now tests the error condition where `ctx.db.get(args.taskId)` returns null because the task does not exist, ensuring it throws the expected "Task not found" error.
✨ **Result:** Test coverage improved for the `completeTask` mutation's error handling paths, increasing reliability and confidence when refactoring.

---
*PR created automatically by Jules for task [3059998724622454100](https://jules.google.com/task/3059998724622454100) started by @BayanBennett*