### PR TITLE
feat: Add user avatar to header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,14 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   allowedDevOrigins: ["192.168.86.49"],
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import Home from "./page";
 import { describe, it, expect, vi } from "vitest";
+import * as authKitComponents from "@workos-inc/authkit-nextjs/components";
+
+vi.mock("next/image", () => ({
+  default: (props: Record<string, unknown>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} data-testid="next-image" />;
+  },
+}));
 
 
 vi.mock("@workos-inc/authkit-nextjs/components", () => ({
@@ -60,6 +68,55 @@ describe("Home Page", () => {
     expect(screen.getByText(/Eudemonic Tasks/i)).toBeInTheDocument();
     expect(consoleSpy).not.toHaveBeenCalled();
     
+    consoleSpy.mockRestore();
+  });
+
+  it("renders the default User icon when user is logged in but has no profilePictureUrl", () => {
+    const useAuthSpy = vi.spyOn(authKitComponents, "useAuth");
+    useAuthSpy.mockReturnValue({
+      user: { id: "user-123", email: "test@example.com", profilePictureUrl: null } as unknown as ReturnType<typeof authKitComponents.useAuth>,
+      organizationId: undefined,
+      signOut: vi.fn(),
+      getAuth: vi.fn() as unknown,
+      refreshAuth: vi.fn() as unknown,
+    } as unknown as ReturnType<typeof authKitComponents.useAuth>);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { container } = render(<Home />);
+
+    expect(screen.getByText(/Sign out/i)).toBeInTheDocument();
+
+    // The lucide User icon should be present, but Image should not
+    const image = screen.queryByTestId("next-image");
+    expect(image).not.toBeInTheDocument();
+
+    // check for the User SVG. It has the class "text-zinc-500" from our implementation
+    const svgIcon = container.querySelector('svg.lucide-user');
+    expect(svgIcon).toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("renders the user's profile picture using Image when profilePictureUrl is present", () => {
+    const useAuthSpy = vi.spyOn(authKitComponents, "useAuth");
+    useAuthSpy.mockReturnValue({
+      user: { id: "user-123", email: "test@example.com", profilePictureUrl: "https://example.com/avatar.png" } as unknown as ReturnType<typeof authKitComponents.useAuth>,
+      organizationId: undefined,
+      signOut: vi.fn(),
+      getAuth: vi.fn() as unknown,
+      refreshAuth: vi.fn() as unknown,
+    } as unknown as ReturnType<typeof authKitComponents.useAuth>);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<Home />);
+
+    expect(screen.getByText(/Sign out/i)).toBeInTheDocument();
+
+    const image = screen.getByTestId("next-image");
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute("src", "https://example.com/avatar.png");
+    expect(image).toHaveAttribute("alt", "Profile picture");
+
     consoleSpy.mockRestore();
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { Check, User } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
 import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function Home() {
   const [captureText, setCaptureText] = useState("");
@@ -86,14 +87,29 @@ export default function Home() {
               Aligning effort with your neurobiology.
             </p>
           </div>
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center">
             {authUser ? (
-              <button
-                onClick={() => signOut()}
-                className="text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
-              >
-                Sign out
-              </button>
+              <>
+                <div className="flex items-center justify-center w-8 h-8 rounded-full overflow-hidden bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700">
+                  {authUser.profilePictureUrl ? (
+                    <Image
+                      src={authUser.profilePictureUrl}
+                      alt="Profile picture"
+                      width={32}
+                      height={32}
+                      className="object-cover"
+                    />
+                  ) : (
+                    <User className="w-5 h-5 text-zinc-500 dark:text-zinc-400" />
+                  )}
+                </div>
+                <button
+                  onClick={() => signOut()}
+                  className="text-sm font-medium text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+                >
+                  Sign out
+                </button>
+              </>
             ) : (
               <>
                 <Link


### PR DESCRIPTION
- Modified `src/app/page.tsx` to display an avatar next to the sign out button if the user is authenticated. 
- The image uses `authUser.profilePictureUrl` if it exists.
- The `next/image` domain is handled via wildcard remote patterns in `next.config.ts`.
- If `authUser.profilePictureUrl` is not present, it renders `lucide-react`'s `User` component instead.
- Added corresponding tests for different image fallback scenarios in `src/app/page.test.tsx`.

---
*PR created automatically by Jules for task [3810405001460659233](https://jules.google.com/task/3810405001460659233) started by @BayanBennett*