### PR TITLE
⚡ Optimize syncUser with concurrent queries

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -91,10 +91,19 @@ export const syncUser = mutation({
 
     const orgIdToUse = args.workosOrgId ?? args.tokenIdentifier;
 
-    let org = await ctx.db
-      .query("organizations")
-      .withIndex("by_workosOrgId", (q) => q.eq("workosOrgId", orgIdToUse))
-      .unique();
+    let org;
+    const [fetchedOrg, user] = await Promise.all([
+      ctx.db
+        .query("organizations")
+        .withIndex("by_workosOrgId", (q) => q.eq("workosOrgId", orgIdToUse))
+        .unique(),
+      ctx.db
+        .query("users")
+        .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", args.tokenIdentifier))
+        .unique(),
+    ]);
+
+    org = fetchedOrg;
 
     if (!org) {
       const orgId = await ctx.db.insert("organizations", {
@@ -108,11 +117,6 @@ export const syncUser = mutation({
         billingTier: "free",
       };
     }
-
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", args.tokenIdentifier))
-      .unique();
 
     if (!user) {
       await ctx.db.insert("users", {


### PR DESCRIPTION
💡 **What:** The optimization uses `Promise.all` to fetch both the organization and user concurrently instead of sequentially.
🎯 **Why:** Fetching user data doesn't depend on the organization data response. Fetching these properties sequentially results in an unnecessary block for network I/O which slows down the query. Running them concurrently improves latency and reduces overall execution time.
📊 **Measured Improvement:** In the local simulated Convex environment using `convex-test`, executing queries concurrently via `Promise.all` does not show a meaningful performance improvement because the local environment does not simulate network latency or real-world database I/O wait times. The local baseline was ~1.01ms for new users and ~0.91ms for existing users, and the concurrent execution resulted in nearly identical timings. However, in a real cloud deployment, independent sequential database queries will incur a full network roundtrip and I/O wait sequentially, thus creating a longer latency bottleneck. Fetching these items in parallel effectively cuts the expected latency roughly in half since the longest query sets the bottleneck.

---
*PR created automatically by Jules for task [12907803327801269925](https://jules.google.com/task/12907803327801269925) started by @BayanBennett*