### PR TITLE
🧹 Code Health: Replace explicit 'any' with expected Id type in fakeId

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
+import { Id } from "./_generated/dataModel";
 import schema from "./schema";
 import {
   listTasks,
@@ -214,7 +215,6 @@ describe("tasks", () => {
     const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_nonexistent", subject: "user_nonexistent" });
     const fakeId = "jd10wtp2eb15a2h7z1s7c0b050m7";
     // @ts-expect-error - vitest environment
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await expect(tWithIdentity.mutation(completeTask, { taskId: fakeId as any })).rejects.toThrow("Task not found");
+    await expect(tWithIdentity.mutation(completeTask, { taskId: fakeId as Id<"tasks"> })).rejects.toThrow("Task not found");
   });
 });


### PR DESCRIPTION
🎯 **What:** Replaced `fakeId as any` with `fakeId as Id<"tasks">` and removed the corresponding eslint disable comment in `convex/functions.test.ts`.

💡 **Why:** Using the proper type (`Id<"tasks">`) is a safer approach than casting to `any` and suppressing the eslint warning, improving maintainability and readability without sacrificing test correctness.

✅ **Verification:** Verified changes by running `pnpm run typecheck`, `pnpm run lint`, and `pnpm run test`, which all completed successfully and without errors.

✨ **Result:** Improved type safety and cleaner test code.

---
*PR created automatically by Jules for task [5279946211656295530](https://jules.google.com/task/5279946211656295530) started by @BayanBennett*