### PR TITLE
🧹 Fix @ts-expect-error on useAuth user organizationId in page.tsx

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
   const [captureText, setCaptureText] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const { user: authUser, signOut } = useAuth();
+  const { user: authUser, organizationId, signOut } = useAuth();
   const { isAuthenticated } = useConvexAuth();
 
   const syncUser = useMutation(api.functions.syncUser);
@@ -34,11 +34,10 @@ export default function Home() {
       // Create/sync user if they are logged in but don't exist in our db yet
       syncUser({
         tokenIdentifier: authUser.id,
-        // @ts-expect-error - missing orgId from typing
-        workosOrgId: authUser.organizationId || undefined,
+        workosOrgId: organizationId || undefined,
       }).catch(console.error);
     }
-  }, [user, authUser, syncUser]);
+  }, [user, authUser, syncUser, organizationId]);
 
   const createTask = useMutation(api.functions.createTask);
   const completeTask = useMutation(api.functions.completeTask);


### PR DESCRIPTION
🎯 **What:** Destructured `organizationId` directly from `useAuth()` instead of trying to access it from `authUser.organizationId`, removing the need for a `@ts-expect-error`.

💡 **Why:** `@workos-inc/authkit-nextjs` components' `useAuth` hook returns an object (`AuthContextType`) containing both `user` and `organizationId` directly at the top level. The previous code was incorrectly trying to access `organizationId` on the `user` property (`authUser`), which caused a TypeScript error because `User` interface doesn't have `organizationId`. Rather than ignoring the error, fetching the ID correctly from `useAuth()` fixes the typing organically and prevents potential runtime errors.

✅ **Verification:** Ran `pnpm test` and `pnpm typecheck` to verify tests passed successfully, no broken behaviors, and typecheck returned green.

✨ **Result:** Cleaned up code, removed `@ts-expect-error` comment, improved maintainability and strict typing.

---
*PR created automatically by Jules for task [4443620525573298136](https://jules.google.com/task/4443620525573298136) started by @BayanBennett*