### PR TITLE
🧹 [Code Health] Remove @ts-expect-error in test setup

### DIFF
--- a/src/app/sign-in/route.test.ts
+++ b/src/app/sign-in/route.test.ts
@@ -19,8 +19,7 @@ describe('Sign In API Route', () => {
   it('should redirect to the sign in url on success', async () => {
     const mockUrl = 'https://example.com/sign-in';
     vi.mocked(getSignInUrl).mockResolvedValue(mockUrl);
-    // @ts-expect-error - vitest environment mocking redirect response
-    vi.mocked(redirect).mockReturnValue('mock-redirect-response');
+    vi.mocked(redirect).mockReturnValue('mock-redirect-response' as never);
 
     const response = await GET();
 


### PR DESCRIPTION
🎯 What: Removed the `@ts-expect-error` directive in `src/app/sign-in/route.test.ts` and correctly typed the mocked `redirect` function by casting its return value to `never`.
💡 Why: Next.js's `redirect` function is typed to return `never`. When mocking it to return a string for testing purposes, casting to `never` cleanly satisfies the TypeScript compiler, eliminating the need to use `@ts-expect-error`. This improves type safety by avoiding the suppression of other potential TS errors on the same line.
✅ Verification: Ran the full test suite (`pnpm test`) and typechecking (`npx tsc --noEmit`), ensuring no regressions were introduced and that all checks still pass.
✨ Result: Cleaner test code that properly handles TS definitions without suppressing compiler checks.

---
*PR created automatically by Jules for task [4840172048848352819](https://jules.google.com/task/4840172048848352819) started by @BayanBennett*