### PR TITLE
🧪 Add test for unauthorized organization access in listTasks

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -196,4 +196,18 @@ describe("tasks", () => {
     const fakeId = "jd10wtp2eb15a2h7z1s7c0b050m7";
     await expect(tWithIdentity.mutation(api.functions.completeTask, { taskId: fakeId as Id<"tasks"> })).rejects.toThrow("Validator error: Expected ID for table");
   });
+
+  it("should throw an error when listing tasks from a different org", async () => {
+    const t = initTest();
+
+    // Setup: Create org 1 and user 1
+    const orgId1 = await setupUserAndOrg(t, "user_1", "org_1");
+
+    // Setup: Create org 2 and user 2
+    await setupUserAndOrg(t, "user_2", "org_2");
+
+    // Action: User 2 tries to list User 1's tasks
+    const tWithIdentity2 = t.withIdentity({ tokenIdentifier: "user_2", subject: "user_2" });
+    await expect(tWithIdentity2.query(api.functions.listTasks, { orgId: orgId1 })).rejects.toThrow("Unauthorized");
+  });
 });


### PR DESCRIPTION
🎯 **What:** Adds a test case to verify that an error is thrown when a user attempts to access tasks from an organization they do not belong to using the \`listTasks\` query.
📊 **Coverage:** Tests unauthorized access scenario for \`listTasks\`.
✨ **Result:** Improved test coverage for security rules.

---
*PR created automatically by Jules for task [2687788601244056709](https://jules.google.com/task/2687788601244056709) started by @BayanBennett*