### PR TITLE
🧪 Add tests for unauthenticated and unauthorized access in getUser

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -210,4 +210,19 @@ describe("tasks", () => {
     const tWithIdentity2 = t.withIdentity({ tokenIdentifier: "user_2", subject: "user_2" });
     await expect(tWithIdentity2.query(api.functions.listTasks, { orgId: orgId1 })).rejects.toThrow("Unauthorized");
   });
+
+  it("should throw an error when getting a user unauthenticated", async () => {
+    const t = initTest();
+
+    // Action: Get a user without identity
+    await expect(t.query(api.functions.getUser, { tokenIdentifier: "user_unauth" })).rejects.toThrow("Unauthenticated call to getUser");
+  });
+
+  it("should throw an error when getting a different user's profile", async () => {
+    const t = initTest();
+
+    // Action: Get a user with different tokenIdentifier than identity
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_actual", subject: "user_actual" });
+    await expect(tWithIdentity.query(api.functions.getUser, { tokenIdentifier: "user_other" })).rejects.toThrow("Unauthorized to access this user");
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds two missing tests for the `getUser` convex function in `convex/functions.test.ts`. Specifically, it covers the scenarios where `getUser` is called unauthenticated or when the authenticated user attempts to request another user's `tokenIdentifier`.

📊 **Coverage:** What scenarios are now tested
1. Unauthenticated call to `getUser` throws `"Unauthenticated call to getUser"`.
2. Unauthorized access where `identity.subject !== args.tokenIdentifier` throws `"Unauthorized to access this user"`.

✨ **Result:** The improvement in test coverage
The test coverage is improved by ensuring that both security checks inside the `getUser` function are effectively verified, completing the testing suite alongside similar existing tests for the `syncUser` function.

---
*PR created automatically by Jules for task [8908752150516097880](https://jules.google.com/task/8908752150516097880) started by @BayanBennett*