### PR TITLE
chore: install and configure WorkOS AuthKit for Convex

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,7 +8,9 @@
  * @module
  */
 
+import type * as auth from "../auth.js";
 import type * as functions from "../functions.js";
+import type * as http from "../http.js";
 
 import type {
   ApiFromModules,
@@ -17,7 +19,9 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  auth: typeof auth;
   functions: typeof functions;
+  http: typeof http;
 }>;
 
 /**
@@ -46,4 +50,6 @@ export declare const internal: FilterApi<
   FunctionReference<any, "internal">
 >;
 
-export declare const components: {};
+export declare const components: {
+  workOSAuthKit: import("@convex-dev/workos-authkit/_generated/component.js").ComponentApi<"workOSAuthKit">;
+};

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,0 +1,52 @@
+import { AuthKit } from "@convex-dev/workos-authkit";
+import { components } from "./_generated/api";
+import type { DataModel } from "./_generated/dataModel";
+
+export const authKit = new AuthKit<DataModel>(components.workOSAuthKit, {});
+
+export const { authKitEvent } = authKit.events({
+  "user.created": async (ctx, event) => {
+    const tokenIdentifier = event.data.id;
+    const workosOrgId = event.data.id;
+
+    let org = await ctx.db
+      .query("organizations")
+      .withIndex("by_workosOrgId", (q) => q.eq("workosOrgId", workosOrgId))
+      .unique();
+
+    if (!org) {
+      const orgId = await ctx.db.insert("organizations", {
+        workosOrgId: workosOrgId,
+        billingTier: "free",
+      });
+      org = await ctx.db.get(orgId);
+    }
+
+    if (org) {
+      const existingUser = await ctx.db
+        .query("users")
+        .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", tokenIdentifier))
+        .unique();
+
+      if (!existingUser) {
+        await ctx.db.insert("users", {
+          tokenIdentifier: tokenIdentifier,
+          orgId: org._id,
+          role: "admin",
+        });
+      }
+    }
+  },
+  "user.updated": async () => {
+  },
+  "user.deleted": async (ctx, event) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_tokenIdentifier", (q) => q.eq("tokenIdentifier", event.data.id))
+      .unique();
+
+    if (user) {
+      await ctx.db.delete(user._id);
+    }
+  }
+});

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,0 +1,6 @@
+import workOSAuthKit from "@convex-dev/workos-authkit/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(workOSAuthKit);
+export default app;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,6 @@
+import { httpRouter } from "convex/server";
+import { authKit } from "./auth";
+
+const http = httpRouter();
+authKit.registerRoutes(http);
+export default http;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@convex-dev/workos-authkit": "^0.2.6",
     "@tsconfig/next": "^2.0.6",
     "@workos-inc/authkit-nextjs": "^4.1.1",
     "convex": "^1.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@convex-dev/workos-authkit':
+        specifier: ^0.2.6
+        version: 0.2.6(@standard-schema/spec@1.1.0)(@workos-inc/authkit-react@0.16.1(react@19.2.7))(@workos-inc/node@9.3.1)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
       '@tsconfig/next':
         specifier: ^2.0.6
         version: 2.0.6
@@ -188,6 +191,33 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@convex-dev/workflow@0.4.4':
+    resolution: {integrity: sha512-ZQfVspAAxG4zZJEep2qaRtupw8OewwMezq6KNKaXKjo/gA+YffS9bXz13x+L/TSt9/Lb6gioae6Y9PDrqh7xQg==}
+    peerDependencies:
+      '@convex-dev/workpool': ^0.4.4
+      convex: ^1.36.1
+      convex-helpers: ^0.1.99
+
+  '@convex-dev/workos-authkit@0.2.6':
+    resolution: {integrity: sha512-tkULdZG4NiF6JqCTrAWrx8rh/DdCCVGSIZuN0q/LpD4KAebplTbof1p3/oWQMdqB6pqeUQBp3dovEpBgVjQbwg==}
+    peerDependencies:
+      '@workos-inc/authkit-react': ^0.13.0 || ^0.16.0
+      '@workos-inc/node': ^7.75.1 || ^8.0.0 || ^9.0.0
+      convex: ^1.29.3
+      react: ^18.3.1 || ^19.0.0
+
+  '@convex-dev/workos@0.0.3':
+    resolution: {integrity: sha512-2gHEm8heSpwDakP+s81tXgHuBDUtUOOvt1RjsoiUJpxUmuF4Ln7mWJt+Dr/I0gCP1wuY2r1N62YIafgOXcbx9Q==}
+    peerDependencies:
+      convex: ^1.39.1
+      react: ^18.0.0 || ^19.0.0-0 || ^19.0.0
+
+  '@convex-dev/workpool@0.4.7':
+    resolution: {integrity: sha512-4O3VKcJXqYZ9icDgKdVPxjDGUAFK3oG0hbUwLcyYMYgsvVKlZDhvZRmczqSBZHLyrCGPpf925byh0dBigCfAGA==}
+    peerDependencies:
+      convex: ^1.31.7
+      convex-helpers: ^0.1.94
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -1155,6 +1185,9 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  '@workos-inc/authkit-js@0.20.0':
+    resolution: {integrity: sha512-8+sw8eH1+XCt3NDoIB2bKKbHvq1N7CVFJeyq1uVrUWG83GCIbNNrFwWrocVNfeQJyhKsVVuDpRcp03iSVsK5Gg==}
+
   '@workos-inc/authkit-nextjs@4.1.1':
     resolution: {integrity: sha512-j7kf3xw2inF8UdhrOOQMoIkCPJaf7CppmJtagDqpeLO9uLoVpnickJCOkrCpY16hIWcJPGdmXTOeaEPIYtu5XQ==}
     engines: {node: '>=22.11.0'}
@@ -1162,6 +1195,11 @@ packages:
       next: ^13.5.9 || ^14.2.26 || ^15.2.3 || ^16
       react: ^18.0 || ^19.0.0
       react-dom: ^18.0 || ^19.0.0
+
+  '@workos-inc/authkit-react@0.16.1':
+    resolution: {integrity: sha512-u8IJsAAyZFFM02+3JhvvNTopSNQoJk/hjOoBlmOkh6j+AnVYrR8hjzJn8j3m9Vi5tRE0il7mpsEDT9fI2xRNjg==}
+    peerDependencies:
+      react: '>=17'
 
   '@workos-inc/node@9.3.1':
     resolution: {integrity: sha512-z6+V5lPAdEtJ2IklAsOUJWv5guihkMbtC8WHmLCKOJYLa/H0j9bRj/OmxTs7T+bzL2dhItxPRarhxlAAq/0jgQ==}
@@ -1237,6 +1275,9 @@ packages:
   ast-v8-to-istanbul@1.0.3:
     resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
+  async-channel@0.2.0:
+    resolution: {integrity: sha512-BJyjI/sfKlyijaBt2hbOSxT28xGNtLR0QLzAKO1Hlnv5BULY7sAoYoTPW3lfr1ZIC7y+FxabxO9T8GXpyoofGg==}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1311,6 +1352,28 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convex-helpers@0.1.119:
+    resolution: {integrity: sha512-fGNK9KAlBLk8Un729ZXBqD9S5jy910nxSrH6PloIL/Gl6TalFJvjN8+xCCwahlox8Ft+bb54SSg9MbcrsQb98w==}
+    hasBin: true
+    peerDependencies:
+      '@standard-schema/spec': ^1.0.0
+      convex: ^1.32.0
+      hono: ^4.0.5
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      typescript: ^5.5 || ^6.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@standard-schema/spec':
+        optional: true
+      hono:
+        optional: true
+      react:
+        optional: true
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   convex-test@0.0.53:
     resolution: {integrity: sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ==}
@@ -2475,6 +2538,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -2531,6 +2598,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2894,6 +2965,41 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@convex-dev/workflow@0.4.4(@convex-dev/workpool@0.4.7(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7)))(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7))':
+    dependencies:
+      '@convex-dev/workpool': 0.4.7(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7))
+      async-channel: 0.2.0
+      convex: 1.40.0(react@19.2.7)
+      convex-helpers: 0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
+
+  '@convex-dev/workos-authkit@0.2.6(@standard-schema/spec@1.1.0)(@workos-inc/authkit-react@0.16.1(react@19.2.7))(@workos-inc/node@9.3.1)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)':
+    dependencies:
+      '@convex-dev/workflow': 0.4.4(@convex-dev/workpool@0.4.7(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7)))(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7))
+      '@convex-dev/workos': 0.0.3(convex@1.40.0(react@19.2.7))(react@19.2.7)
+      '@convex-dev/workpool': 0.4.7(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7))
+      '@workos-inc/authkit-react': 0.16.1(react@19.2.7)
+      '@workos-inc/node': 9.3.1
+      convex: 1.40.0(react@19.2.7)
+      convex-helpers: 0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
+      react: 19.2.7
+      type-fest: 5.7.0
+    transitivePeerDependencies:
+      - '@standard-schema/spec'
+      - hono
+      - typescript
+      - zod
+
+  '@convex-dev/workos@0.0.3(convex@1.40.0(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@workos-inc/authkit-react': 0.16.1(react@19.2.7)
+      convex: 1.40.0(react@19.2.7)
+      react: 19.2.7
+
+  '@convex-dev/workpool@0.4.7(convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3))(convex@1.40.0(react@19.2.7))':
+    dependencies:
+      convex: 1.40.0(react@19.2.7)
+      convex-helpers: 0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3)
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -3647,6 +3753,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workos-inc/authkit-js@0.20.0': {}
+
   '@workos-inc/authkit-nextjs@4.1.1(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@sindresorhus/fnv1a': 3.1.0
@@ -3660,6 +3768,11 @@ snapshots:
       valibot: 1.4.1(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
+
+  '@workos-inc/authkit-react@0.16.1(react@19.2.7)':
+    dependencies:
+      '@workos-inc/authkit-js': 0.20.0
+      react: 19.2.7
 
   '@workos-inc/node@9.3.1':
     dependencies:
@@ -3765,6 +3878,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  async-channel@0.2.0: {}
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -3832,6 +3947,15 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  convex-helpers@0.1.119(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(zod@4.4.3):
+    dependencies:
+      convex: 1.40.0(react@19.2.7)
+    optionalDependencies:
+      '@standard-schema/spec': 1.1.0
+      react: 19.2.7
+      typescript: 6.0.3
+      zod: 4.4.3
 
   convex-test@0.0.53(convex@1.40.0(react@19.2.7)):
     dependencies:
@@ -5221,6 +5345,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
@@ -5270,6 +5396,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
This PR installs and configures the `@convex-dev/workos-authkit` package for the Next.js/Convex project.

**Changes:**
1. Installed `@convex-dev/workos-authkit`.
2. Created `convex/convex.config.ts` to register the `workOSAuthKit` component.
3. Created `convex/auth.ts` to define the AuthKit client and export the webhook event handlers (`user.created` and `user.deleted`). It correctly handles missing organizations by gracefully inserting an empty default organization when syncing users directly based on the AuthKit events.
4. Created `convex/http.ts` to register the webhooks HTTP route for AuthKit sync.

**Pre-Commit Steps Performed:**
- Checked typecheck using `pnpm typecheck`
- Checked linters using `npm run lint`
- Checked tests using `pnpm test`
- Validated codegen works cleanly with `npx convex codegen`

---
*PR created automatically by Jules for task [10032464486425658832](https://jules.google.com/task/10032464486425658832) started by @BayanBennett*