### PR TITLE
🧹 Remove test helpers from production API

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { convexTest } from "convex-test";
 import { Id } from "./_generated/dataModel";
 import schema from "./schema";
-import { api, internal } from "./_generated/api";
+import { api } from "./_generated/api";
 
 function initTest() {
   const modules = import.meta.glob("./**/*.*s");
@@ -20,14 +20,17 @@ async function captureTask(t: ReturnType<typeof initTest>, userId: string, rawCa
 }
 
 async function setupUserAndOrg(t: ReturnType<typeof initTest>, userId: string, orgIdStr: string) {
-  const orgId = await t.mutation(internal.functions.testSetupOrg, {
-    workosOrgId: orgIdStr,
-    billingTier: "pro",
-  });
-  await t.mutation(internal.functions.testSetupUser, {
-    tokenIdentifier: userId,
-    orgId,
-    role: "admin",
+  const orgId = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("organizations", {
+      workosOrgId: orgIdStr,
+      billingTier: "pro",
+    });
+    await ctx.db.insert("users", {
+      tokenIdentifier: userId,
+      orgId: id,
+      role: "admin",
+    });
+    return id;
   });
   return orgId;
 }

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -1,4 +1,4 @@
-import { query, mutation, internalMutation, QueryCtx, MutationCtx } from "./_generated/server";
+import { query, mutation, QueryCtx, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 
 async function enforceUser(
@@ -55,27 +55,6 @@ export const createTask = mutation({
       energyRequired: 5,
     });
     return taskId;
-  },
-});
-
-export const testSetupOrg = internalMutation({
-  args: { workosOrgId: v.string(), billingTier: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db.insert("organizations", {
-      workosOrgId: args.workosOrgId,
-      billingTier: args.billingTier,
-    });
-  },
-});
-
-export const testSetupUser = internalMutation({
-  args: { tokenIdentifier: v.string(), orgId: v.id("organizations"), role: v.string() },
-  handler: async (ctx, args) => {
-    return await ctx.db.insert("users", {
-      tokenIdentifier: args.tokenIdentifier,
-      orgId: args.orgId,
-      role: args.role,
-    });
   },
 });
 


### PR DESCRIPTION
🎯 **What:** Removed the `testSetupOrg` and `testSetupUser` helper mutations from the `convex/functions.ts` file, and refactored the corresponding tests in `convex/functions.test.ts` to insert data directly into the database using `t.run`.

💡 **Why:** `testSetupOrg` and `testSetupUser` are strictly test utilities. However, anything exported from files inside the `convex/` directory gets automatically deployed as an endpoint by Convex. Leaving test setup functions in the production API pollutes the endpoints and potentially exposes testing functionality. Replacing them with direct database operations within the test's `t.run` context leverages `convex-test`'s capabilities to manage test state locally and keeps the production API clean.

✅ **Verification:** Verified by ensuring the code correctly compiles (`pnpm typecheck`), the type definitions are updated correctly (`npx convex codegen`), linting is clean (`pnpm lint`), and the test suite passes (`pnpm test`), confirming all functionality remains exactly the same while safely replacing test helper calls with direct database inserts.

✨ **Result:** The `convex/functions.ts` endpoint is now clean, exposing only true production APIs, and test setups correctly use built-in context functions rather than dummy deployment targets.

---
*PR created automatically by Jules for task [12094872446885514070](https://jules.google.com/task/12094872446885514070) started by @BayanBennett*