### PR TITLE
🧪 Add unit test for auth callback route

### DIFF
--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleAuth } from '@workos-inc/authkit-nextjs';
+import { GET } from './route';
+
+vi.mock('@workos-inc/authkit-nextjs', () => ({
+  handleAuth: vi.fn(() => 'mock-handle-auth-response'),
+}));
+
+describe('Auth Callback API Route', () => {
+  it('should export the result of handleAuth as GET', () => {
+    // Assert that handleAuth was called during module evaluation
+    expect(handleAuth).toHaveBeenCalled();
+    // Assert that GET has the value returned by handleAuth
+    expect(GET).toBe('mock-handle-auth-response');
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a missing unit test file (`src/app/auth/callback/route.test.ts`) for the WorkOS AuthKit callback route handler.
📊 **Coverage:** Tests that the route handler correctly evaluates and exports the `GET` handler derived from the `handleAuth()` function provided by `@workos-inc/authkit-nextjs`.
✨ **Result:** Improved test coverage for the authentication flow, ensuring that the critical callback route isn't accidentally modified or broken during refactoring.

---
*PR created automatically by Jules for task [13428060559467502859](https://jules.google.com/task/13428060559467502859) started by @BayanBennett*