### PR TITLE
🔒 Fix overly permissive image remote patterns in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "**",
+        hostname: "images.workoscdn.com",
       },
     ],
   },


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `next.config.ts` was configured with an overly permissive wildcard `**` for `images.remotePatterns`. This means Next.js's built-in Image Optimization API could be abused as a proxy for any external image, potentially leading to Server-Side Request Forgery (SSRF) scenarios or unexpectedly high bandwidth/compute billing if attackers passed arbitrary remote image URLs through the application.

⚠️ **Risk:** The potential impact if left unfixed
Malicious actors could use the application's resources to proxy or optimize illicit, oversized, or malicious images on their behalf. Additionally, it exposes the application to significant financial risk via denial of wallet attacks due to Next.js image optimization compute costs.

🛡️ **Solution:** How the fix addresses the vulnerability
The configuration was tightened by explicitly specifying `hostname: "images.workoscdn.com"`. By allowing only the required WorkOS CDN (used for user profile avatars), we block optimization and proxying of unauthorized external images.

---
*PR created automatically by Jules for task [17845935584968270987](https://jules.google.com/task/17845935584968270987) started by @BayanBennett*