### PR TITLE
🔒 Fix missing length validation on rawCapture

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -54,6 +54,21 @@ describe("tasks", () => {
     );
   });
 
+  it("should throw an error when rawCapture exceeds the maximum length", async () => {
+    const t = initTest();
+
+    // Setup: Create an org and user
+    await setupUserAndOrg(t, "user_length", "org_length");
+
+    // Action: Create a task with a massive rawCapture string
+    const longString = "a".repeat(4097);
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_length", subject: "user_length" });
+    const promise = tWithIdentity.mutation(api.functions.createTask, { rawCapture: longString });
+
+    // Validation: Check that it throws an error
+    await expect(promise).rejects.toThrow("rawCapture exceeds maximum length of 4096 characters");
+  });
+
   it("should create and list tasks", async () => {
     const t = initTest();
 

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -1,5 +1,5 @@
 import { query, mutation, QueryCtx, MutationCtx } from "./_generated/server";
-import { v } from "convex/values";
+import { v, ConvexError } from "convex/values";
 
 async function enforceUser(
   ctx: QueryCtx | MutationCtx,
@@ -43,6 +43,10 @@ export const createTask = mutation({
     rawCapture: v.string(),
   },
   handler: async (ctx, args) => {
+    if (args.rawCapture.length > 4096) {
+      throw new ConvexError("rawCapture exceeds maximum length of 4096 characters");
+    }
+
     const user = await enforceUser(ctx, "Unauthenticated call to createTask");
 
     const taskId = await ctx.db.insert("tasks", {

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,5 @@
+🎯 What: Added length validation to the `rawCapture` field in the `createTask` mutation in `convex/functions.ts`. A new test is added in `convex/functions.test.ts` to assert the length constraint.
+
+⚠️ Risk: The absence of string length validation for raw text insertion exposes the system to Denial of Service (DoS) and potential storage exhaustion. An attacker could flood the system with excessively large strings, consuming resources, degrading system performance, or artificially inflating database storage costs.
+
+🛡️ Solution: A length check was implemented natively inside the `createTask` mutation handler because `v.string()` does not support built-in bounds. Any `rawCapture` input exceeding 4096 characters triggers a `ConvexError`, preventing the record from being stored.


### PR DESCRIPTION
🎯 What: Added length validation to the `rawCapture` field in the `createTask` mutation in `convex/functions.ts`. A new test is added in `convex/functions.test.ts` to assert the length constraint.

⚠️ Risk: The absence of string length validation for raw text insertion exposes the system to Denial of Service (DoS) and potential storage exhaustion. An attacker could flood the system with excessively large strings, consuming resources, degrading system performance, or artificially inflating database storage costs.

🛡️ Solution: A length check was implemented natively inside the `createTask` mutation handler because `v.string()` does not support built-in bounds. Any `rawCapture` input exceeding 4096 characters triggers a `ConvexError`, preventing the record from being stored.

---
*PR created automatically by Jules for task [14073167066027045061](https://jules.google.com/task/14073167066027045061) started by @BayanBennett*