### PR TITLE
🔒 Fix IDOR vulnerability in syncUser mutation

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -36,10 +36,10 @@ async function setupUserAndOrg(t: ReturnType<typeof initTest>, userId: string, o
 }
 
 async function performSyncUser(t: ReturnType<typeof initTest>, userId: string, workosOrgId?: string) {
-  const tWithIdentity = t.withIdentity({ tokenIdentifier: userId, subject: userId });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tWithIdentity = t.withIdentity({ tokenIdentifier: userId, subject: userId, org_id: workosOrgId } as any);
   return await tWithIdentity.mutation(api.functions.syncUser, {
     tokenIdentifier: userId,
-    workosOrgId,
   });
 }
 

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -64,7 +64,7 @@ export const createTask = mutation({
 });
 
 export const syncUser = mutation({
-  args: { tokenIdentifier: v.string(), workosOrgId: v.optional(v.string()) },
+  args: { tokenIdentifier: v.string() },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
@@ -74,7 +74,8 @@ export const syncUser = mutation({
       throw new Error("Unauthorized to sync this user");
     }
 
-    const orgIdToUse = args.workosOrgId ?? args.tokenIdentifier;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const orgIdToUse = (identity as any).org_id ?? args.tokenIdentifier;
 
     let org;
     const [fetchedOrg, user] = await Promise.all([

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,7 +36,6 @@ export default function Home() {
       // Create/sync user if they are logged in but don't exist in our db yet
       syncUser({
         tokenIdentifier: authUser.id,
-        workosOrgId: organizationId || undefined,
       }).catch(() => setError("Failed to sync user profile. Please try refreshing."));
     }
   }, [user, authUser, syncUser, organizationId]);


### PR DESCRIPTION
🎯 **What:** The `syncUser` mutation accepted `workosOrgId` as an argument from the client, leading to an Insecure Direct Object Reference (IDOR) vulnerability.
⚠️ **Risk:** A malicious client could provide an arbitrary `workosOrgId`, bypassing the intended authorization flow and improperly associating themselves with another organization in the database, potentially exposing sensitive tasks and data.
🛡️ **Solution:** Removed the `workosOrgId` argument from the mutation entirely. The organization ID is now securely extracted from the authenticated user's trusted custom JWT claim (`org_id`). If the claim is missing, it falls back to the `tokenIdentifier`. Updated corresponding client code and unit tests.

---
*PR created automatically by Jules for task [7878669741663041995](https://jules.google.com/task/7878669741663041995) started by @BayanBennett*