### PR TITLE
🔒 fix(security): redact sensitive token error logs

### DIFF
--- a/src/app/ConvexClientProvider.tsx
+++ b/src/app/ConvexClientProvider.tsx
@@ -40,8 +40,8 @@ function useAuthFromAuthKit() {
         }
 
         return (await getAccessToken()) ?? null;
-      } catch (error) {
-        console.error('Failed to get access token:', error);
+      } catch {
+        console.error('Failed to get access token');
         return null;
       }
     },


### PR DESCRIPTION
🔒 [Security] Redact sensitive access token error logs

🎯 **What:**
The vulnerability fixed here is the exposure of detailed access token error objects to the client-side console in `src/app/ConvexClientProvider.tsx`. The raw `error` object from the catch block was previously being logged verbatim.

⚠️ **Risk:**
If left unfixed, detailed authentication token retrieval errors could expose sensitive internal structure data, error traces, or configuration details to the end user's browser console, posing an information disclosure risk.

🛡️ **Solution:**
Replaced `catch (error) { console.error('Failed to get access token:', error); }` with `catch { console.error('Failed to get access token'); }`. This completely removes the error object from the client console log while preserving generic failure notification logic.

---
*PR created automatically by Jules for task [6291088381464628801](https://jules.google.com/task/6291088381464628801) started by @BayanBennett*