### PR TITLE
🧹 code health: Use named export instead of default export in proxy.ts

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { authkitProxy } from '@workos-inc/authkit-nextjs';
 
-export default authkitProxy({
+export const proxy = authkitProxy({
   redirectUri: process.env.WORKOS_REDIRECT_URI || 'http://localhost:3000/auth/callback',
   middlewareAuth: {
     enabled: true,


### PR DESCRIPTION
🎯 What: Replaced `export default` with `export const proxy` in `src/proxy.ts`.
💡 Why: This resolves a code health/style guide violation regarding the use of default exports and conforms to the Next.js 16+ convention where `proxy.ts` requires a named `proxy` export for middleware to function as documented.
✅ Verification: Ran `pnpm typecheck`, `pnpm lint`, and `pnpm test`. Also successfully ran `pnpm build` to ensure Next.js can resolve and detect the proxy properly without errors.
✨ Result: Codebase aligns with style guide expectations while preserving existing functionality.

---
*PR created automatically by Jules for task [12743256862889827661](https://jules.google.com/task/12743256862889827661) started by @BayanBennett*