### PR TITLE
🧪 Add test for createTask failure handling in Home page

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -160,4 +160,35 @@ describe("Home Page", () => {
     consoleSpy.mockRestore();
   });
 
+  it("sets error state when creating a task fails", async () => {
+    const useAuthSpy = vi.spyOn(authKitComponents, "useAuth");
+    useAuthSpy.mockReturnValue({
+      user: { id: "user-123", email: "test@example.com" } as unknown as ReturnType<typeof authKitComponents.useAuth>,
+      organizationId: undefined,
+      signOut: vi.fn(),
+      getAuth: vi.fn() as unknown,
+      refreshAuth: vi.fn() as unknown,
+    } as unknown as ReturnType<typeof authKitComponents.useAuth>);
+
+    vi.mocked(useMutation).mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return vi.fn().mockRejectedValue(new Error("Failed to create task")) as any;
+    });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<Home />);
+
+    const input = screen.getByPlaceholderText("What's on your mind? (TEA Framework)");
+    fireEvent.change(input, { target: { value: 'New test task' } });
+
+    const captureBtn = screen.getByText("Capture");
+    fireEvent.click(captureBtn);
+
+    await waitFor(() => {
+        expect(screen.getByText("Failed to create task")).toBeInTheDocument();
+    });
+
+    consoleSpy.mockRestore();
+  });
+
 });


### PR DESCRIPTION
🎯 **What:** Added a missing unit test to verify the error state is correctly set when creating a task fails on the Home page.
📊 **Coverage:** Covered the error path in the `handleCapture` function, ensuring that if `createTask` mutation rejects, the `Failed to create task` error message is displayed.
✨ **Result:** Improved test coverage and confidence in error handling when capturing tasks.

---
*PR created automatically by Jules for task [3313057437394126778](https://jules.google.com/task/3313057437394126778) started by @BayanBennett*