### PR TITLE
🧪 Add test for enforceUser when user not found in DB

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -54,6 +54,20 @@ describe("tasks", () => {
     );
   });
 
+  it("should throw an error when user is authenticated but not found in the database", async () => {
+    const t = initTest();
+
+    // Setup: Use an identity that doesn't correspond to any user in the db
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "nonexistent_user", subject: "nonexistent_user" });
+
+    // Action: Create a task
+    const promise = tWithIdentity.mutation(api.functions.createTask, { rawCapture: "Test task" });
+
+    // Validation: Check that it throws an error
+    await expect(promise).rejects.toThrow("User not found");
+  });
+
+
   it("should throw an error when rawCapture exceeds the maximum length", async () => {
     const t = initTest();
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `enforceUser` in `convex/functions.ts` did not have a test covering the scenario where a user successfully authenticates (i.e. has an identity), but their database record does not exist. 
📊 **Coverage:** A new test was added to `convex/functions.test.ts` that triggers the `createTask` mutation with a mocked identity (`t.withIdentity`) whose `subject` does not exist in the test database. 
✨ **Result:** The test suite now reliably verifies that `enforceUser` throws the correct "User not found" error when this edge case occurs, improving our overall test coverage for backend error handling.

---
*PR created automatically by Jules for task [14562331318255883144](https://jules.google.com/task/14562331318255883144) started by @BayanBennett*