### PR TITLE
🧪 Add missing test for completeTask when task is not found

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -217,6 +217,24 @@ describe("tasks", () => {
     });
   });
 
+
+  it("should throw an error when completing a task that is not found", async () => {
+    const t = initTest();
+
+    // Setup: Create an org and user
+    await setupUserAndOrg(t, "user_not_found", "org_not_found");
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_not_found", subject: "user_not_found" });
+
+    // Action: Create a task and then delete it directly from the database
+    const taskId = await tWithIdentity.mutation(api.functions.createTask, { rawCapture: "Test task to delete" });
+    await t.run(async (ctx) => {
+      await ctx.db.delete(taskId);
+    });
+
+    // Validation: Try to complete the deleted task
+    await expect(tWithIdentity.mutation(api.functions.completeTask, { taskId })).rejects.toThrow("Task not found");
+  });
+
   it("should throw an error when completing a non-existent task", async () => {
     const t = initTest();
 


### PR DESCRIPTION
🎯 **What:**
The `completeTask` mutation previously lacked a test verifying its behavior when attempting to complete a task that doesn't exist in the database, even when a syntactically valid ID is provided. A new test case has been added to address this testing gap.

📊 **Coverage:**
The added test covers the specific edge case where `ctx.db.get(args.taskId)` returns `null` because the task was either never created or previously deleted. The test sets up an authorized user, captures a task, deletes it directly from the database to simulate the condition, and then invokes the `completeTask` mutation, asserting that a "Task not found" error is thrown.

✨ **Result:**
Test coverage and reliability for `completeTask` are significantly improved, now properly validating both syntax (via ID validation) and state (existence) errors independently. All tests pass successfully.

---
*PR created automatically by Jules for task [18217612275962844642](https://jules.google.com/task/18217612275962844642) started by @BayanBennett*