### PR TITLE
🔒 [security] Fix privilege escalation risk in syncUser by preventing org ID collisions

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -75,7 +75,7 @@ export const syncUser = mutation({
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const orgIdToUse = (identity as any).org_id ?? args.tokenIdentifier;
+    const orgIdToUse = (identity as any).org_id ?? `personal_${identity.subject}`;
 
     let org;
     const [fetchedOrg, user] = await Promise.all([


### PR DESCRIPTION
🎯 What: Fixed a vulnerability where `args.tokenIdentifier` was used as the fallback organization ID if the user's JWT did not contain an `org_id`.
⚠️ Risk: If a user lacked an `org_id` but somehow manipulated the `args.tokenIdentifier` to match an existing WorkOS organization ID, they could be added to that organization as an admin, bypassing access controls.
🛡️ Solution: Updated the fallback logic to use `personal_${identity.subject}`. This ensures that users without an explicit `org_id` are placed into a uniquely generated personal organization tied strictly to their authenticated identity, preventing any possibility of colliding with a real WorkOS organization ID.

---
*PR created automatically by Jules for task [11477932879755020476](https://jules.google.com/task/11477932879755020476) started by @BayanBennett*