### PR TITLE
🧹 [code health improvement] Fix TypeScript bypasses in Auth test

### DIFF
--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -17,8 +17,7 @@ describe('Auth Callback API Route', () => {
     const mockRequest = new Request('http://localhost/auth/callback');
 
     // In WorkOS authkit nextjs, the route handler returns a function that takes a Request
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await (GET as any)(mockRequest);
+    const result = await (GET as import("vitest").Mock)(mockRequest);
     expect(result).toBe('mock-response');
   });
 
@@ -28,14 +27,12 @@ describe('Auth Callback API Route', () => {
     const mockErrorHandler = vi.fn().mockRejectedValue(new Error('Auth callback failed'));
 
     // We dynamically mock it for the error test
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(handleAuth).mockReturnValueOnce(mockErrorHandler as any);
+    vi.mocked(handleAuth).mockReturnValueOnce(mockErrorHandler as ReturnType<typeof handleAuth>);
 
     // Reload the module
     vi.resetModules();
     const { GET: DynamicGET } = await import('./route');
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await expect((DynamicGET as any)(mockRequest)).rejects.toThrow('Auth callback failed');
+    await expect((DynamicGET as import("vitest").Mock)(mockRequest)).rejects.toThrow('Auth callback failed');
   });
 });


### PR DESCRIPTION
🎯 **What:** Replaced `as any` and `eslint-disable-next-line @typescript-eslint/no-explicit-any` comments with proper test typings in `src/app/auth/callback/route.test.ts`. Mocked handles are typed accurately with `import('vitest').Mock` and `ReturnType<typeof handleAuth>`.
💡 **Why:** Relying on `any` bypasses TypeScript's safety features and obscures the code's expected interfaces, which reduces maintainability.
✅ **Verification:** Ran `pnpm vitest run src/app/auth/callback/route.test.ts` and `pnpm typecheck`, confirmed all typechecks and unit tests pass without errors.
✨ **Result:** Safer test files that adhere to TypeScript checking with proper mocking.

---
*PR created automatically by Jules for task [18124703823695241801](https://jules.google.com/task/18124703823695241801) started by @BayanBennett*