### PR TITLE
🧹 [code health improvement]: Remove `any` cast in `convex/functions.ts`

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -74,8 +74,7 @@ export const syncUser = mutation({
       throw new Error("Unauthorized to sync this user");
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const orgIdToUse = (identity as any).org_id ?? `personal_${identity.subject}`;
+    const orgIdToUse = (identity as typeof identity & { org_id?: string }).org_id ?? `personal_${identity.subject}`;
 
     let org;
     const [fetchedOrg, user] = await Promise.all([


### PR DESCRIPTION
🎯 **What:** Replaced the `(identity as any)` cast with a more specific type assertion `(identity as typeof identity & { org_id?: string })` and removed the corresponding eslint disable comment in `convex/functions.ts`.
💡 **Why:** This change removes a bypass of TypeScript's strict type checking. Using a more accurate intersection type improves the maintainability and type safety of the codebase by explicitly informing the compiler about the structure of the object without resorting to the less safe `any` type.
✅ **Verification:** Ran the full test suite and linters to verify that functionality hasn't regressed and there are no type or linting errors.
✨ **Result:** Improved code health and safety by eliminating `any` usage without altering any runtime behavior.

---
*PR created automatically by Jules for task [9147293355591244](https://jules.google.com/task/9147293355591244) started by @BayanBennett*