### PR TITLE
🧹 [code health improvement] move ConvexClientProvider import to top of layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Spline_Sans } from "next/font/google";
 import "./globals.css";
+import { ConvexClientProvider } from "./ConvexClientProvider";
 
 const splineSans = Spline_Sans({
   variable: "--font-spline-sans",
@@ -11,8 +12,6 @@ export const metadata: Metadata = {
   title: "Eudemonic Task Management",
   description: "A system for human focus and well-being",
 };
-
-import { ConvexClientProvider } from "./ConvexClientProvider";
 
 export default function RootLayout({
   children,


### PR DESCRIPTION
🎯 **What:** Moved the `import { ConvexClientProvider } from "./ConvexClientProvider";` statement to the top of `src/app/layout.tsx` alongside other imports, rather than appearing after the `metadata` export.
💡 **Why:** Having import statements scattered throughout the file after exports reduces readability and violates standard TypeScript conventions. Grouping all imports at the top improves maintainability.
✅ **Verification:** Ran `pnpm run lint`, `pnpm typecheck`, and `pnpm test` (including `src/app/layout.test.tsx`) to ensure no regressions were introduced.
✨ **Result:** The codebase is cleaner and adheres to standard import conventions without any change in functionality.

---
*PR created automatically by Jules for task [9989413180872943690](https://jules.google.com/task/9989413180872943690) started by @BayanBennett*