### PR TITLE
⚡ Optimize listTasks by removing frontend network waterfall

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -87,14 +87,14 @@ describe("tasks", () => {
     const t = initTest();
 
     // Setup: Create a test organization and user
-    const orgId = await setupUserAndOrg(t, "user_123", "org_123");
+    await setupUserAndOrg(t, "user_123", "org_123");
 
     // Action: Create a task
     await captureTask(t, "user_123", "Test task");
 
     // Validation: List tasks
     const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_123", subject: "user_123" });
-    const tasks = await tWithIdentity.query(api.functions.listTasks, { orgId, paginationOpts: { numItems: 10, cursor: null } });
+    const tasks = await tWithIdentity.query(api.functions.listTasks, { paginationOpts: { numItems: 10, cursor: null } });
     expect(tasks.page).toHaveLength(1);
     expect(tasks.page[0].rawCapture).toBe("Test task");
     expect(tasks.page[0].status).toBe("active");
@@ -205,7 +205,7 @@ describe("tasks", () => {
     await tWithIdentity.mutation(api.functions.completeTask, { taskId });
 
     // Validation: Check task status
-    const tasks = await tWithIdentity.query(api.functions.listTasks, { orgId, paginationOpts: { numItems: 10, cursor: null } });
+    const tasks = await tWithIdentity.query(api.functions.listTasks, { paginationOpts: { numItems: 10, cursor: null } });
     // listTasks only returns active tasks now, so it should be empty
     expect(tasks.page).toHaveLength(0);
 
@@ -247,18 +247,20 @@ describe("tasks", () => {
     await expect(tWithIdentity.mutation(api.functions.completeTask, { taskId: fakeId as Id<"tasks"> })).rejects.toThrow("Validator error: Expected ID for table");
   });
 
-  it("should throw an error when listing tasks from a different org", async () => {
+  it("should list tasks from the user's own org", async () => {
     const t = initTest();
 
     // Setup: Create org 1 and user 1
-    const orgId1 = await setupUserAndOrg(t, "user_1", "org_1");
+    await setupUserAndOrg(t, "user_1", "org_1");
 
     // Setup: Create org 2 and user 2
     await setupUserAndOrg(t, "user_2", "org_2");
 
     // Action: User 2 tries to list User 1's tasks
     const tWithIdentity2 = t.withIdentity({ tokenIdentifier: "user_2", subject: "user_2" });
-    await expect(tWithIdentity2.query(api.functions.listTasks, { orgId: orgId1, paginationOpts: { numItems: 10, cursor: null } })).rejects.toThrow("Unauthorized");
+    // Action: User 2 tries to list tasks, they will only see their own tasks
+    const tasks = await tWithIdentity2.query(api.functions.listTasks, { paginationOpts: { numItems: 10, cursor: null } });
+    expect(tasks.page).toHaveLength(0);
   });
 
   it("should throw an error when getting a user unauthenticated", async () => {

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -24,16 +24,13 @@ async function enforceUser(
 }
 
 export const listTasks = query({
-  args: { orgId: v.id("organizations"), paginationOpts: paginationOptsValidator },
+  args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
     const user = await enforceUser(ctx, "Unauthenticated");
-    if (user.orgId !== args.orgId) {
-      throw new Error("Unauthorized");
-    }
     return await ctx.db
       .query("tasks")
       .withIndex("by_orgId_status", (q) =>
-        q.eq("orgId", args.orgId).eq("status", "active")
+        q.eq("orgId", user.orgId).eq("status", "active")
       )
       .paginate(args.paginationOpts);
   },

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,6 +1,3 @@
-💡 **What:** Modified `completeTask` in `convex/functions.ts` to execute `enforceUser` and `ctx.db.get(args.taskId)` concurrently using `Promise.all`.
-🎯 **Why:** Both operations are independent reads that were previously executing sequentially, unnecessarily increasing the total execution time of the mutation.
-📊 **Measured Improvement:** We created a benchmark simulating 500 complete task iterations.
-- **Baseline:** ~198.0ms total (~0.40ms average per call)
-- **Optimized:** ~175.4ms total (~0.35ms average per call)
-- **Improvement:** ~11.4% speed increase per call.
+💡 **What:** Removed `orgId` parameter from `listTasks` and updated the frontend to execute the `listTasks` and `getUser` queries concurrently.
+🎯 **Why:** Previously, `listTasks` required `orgId` which meant the frontend had a network waterfall: it had to wait for `getUser` to finish (yielding the `user.orgId`) before it could dispatch the query for `listTasks`. Because the backend `listTasks` function already enforces authentication via `enforceUser` (which retrieves the user's `orgId` internally), providing `orgId` from the frontend was redundant. Removing it allows both queries to be dispatched concurrently on page load, eliminating the waterfall and significantly reducing Time to Interactive (TTI) for task loading.
+📊 **Measured Improvement:** Since this is a frontend waterfall issue dealing with network latency rather than CPU processing, establishing a micro-benchmark using a local testing framework is impractical and wouldn't reflect real-world network conditions. The improvement is conceptually a 100% reduction in the "wait" step of the waterfall; instead of sequential RTT (Round Trip Time), both initial requests happen in parallel. Assuming a 50ms network RTT to Convex, the page will load active tasks ~50ms faster.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
   // Query active tasks
   const { results: tasks } = usePaginatedQuery(
     api.functions.listTasks,
-    user && isAuthenticated ? { orgId: user.orgId } : "skip",
+    isAuthenticated ? {} : "skip",
     { initialNumItems: 10 }
   );
   const activeTasks = tasks ?? [];


### PR DESCRIPTION
💡 **What:** Removed `orgId` parameter from `listTasks` and updated the frontend to execute the `listTasks` and `getUser` queries concurrently.
🎯 **Why:** Previously, `listTasks` required `orgId` which meant the frontend had a network waterfall: it had to wait for `getUser` to finish (yielding the `user.orgId`) before it could dispatch the query for `listTasks`. Because the backend `listTasks` function already enforces authentication via `enforceUser` (which retrieves the user's `orgId` internally), providing `orgId` from the frontend was redundant. Removing it allows both queries to be dispatched concurrently on page load, eliminating the waterfall and significantly reducing Time to Interactive (TTI) for task loading.
📊 **Measured Improvement:** Since this is a frontend waterfall issue dealing with network latency rather than CPU processing, establishing a micro-benchmark using a local testing framework is impractical and wouldn't reflect real-world network conditions. The improvement is conceptually a 100% reduction in the "wait" step of the waterfall; instead of sequential RTT (Round Trip Time), both initial requests happen in parallel. Assuming a 50ms network RTT to Convex, the page will load active tasks ~50ms faster.

---
*PR created automatically by Jules for task [5125641214631150435](https://jules.google.com/task/5125641214631150435) started by @BayanBennett*