### PR TITLE
🧪 Improve ConvexClientProvider test coverage

### DIFF
--- a/src/app/ConvexClientProvider.test.tsx
+++ b/src/app/ConvexClientProvider.test.tsx
@@ -1,6 +1,6 @@
-import { render } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ConvexClientProvider } from './ConvexClientProvider';
+import { ConvexClientProvider, useAuthFromAuthKit } from './ConvexClientProvider';
 import React from 'react';
 
 // Mock dependencies
@@ -62,5 +62,17 @@ describe('ConvexClientProvider', () => {
     }).toThrow('NEXT_PUBLIC_CONVEX_URL environment variable is not defined');
 
     consoleError.mockRestore();
+  });
+});
+
+
+describe('useAuthFromAuthKit', () => {
+  it('fetchAccessToken returns null when user is null', async () => {
+    const { result } = renderHook(() => useAuthFromAuthKit());
+
+    // fetchAccessToken is async
+    const token = await result.current.fetchAccessToken();
+
+    expect(token).toBeNull();
   });
 });

--- a/src/app/ConvexClientProvider.tsx
+++ b/src/app/ConvexClientProvider.tsx
@@ -22,7 +22,7 @@ export function ConvexClientProvider({ children }: { children: ReactNode }) {
   );
 }
 
-function useAuthFromAuthKit() {
+export function useAuthFromAuthKit() {
   const { user, loading: isLoading } = useAuth();
   const { getAccessToken, refresh } = useAccessToken();
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Added missing edge case test for `fetchAccessToken` when `user` is null.
📊 **Coverage:** What scenarios are now tested: Tested the `useAuthFromAuthKit` hook using `renderHook` to verify `fetchAccessToken` returns null without a user.
✨ **Result:** The improvement in test coverage: Improved overall test coverage and ensures correct auth behavior in edge cases.

---
*PR created automatically by Jules for task [9089835701228648719](https://jules.google.com/task/9089835701228648719) started by @BayanBennett*