### PR TITLE
🧹 [code health] Remove `as any` type casting in tests

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -139,12 +139,10 @@ describe("Home Page", () => {
       results: [{ _id: "task-1", rawCapture: "Test task to complete" }],
       status: "Exhausted",
       loadMore: vi.fn()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any);
+    } as unknown as ReturnType<typeof usePaginatedQuery>);
 
     vi.mocked(useMutation).mockImplementation(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return vi.fn().mockRejectedValue(new Error("Failed to complete task")) as any;
+        return vi.fn().mockRejectedValue(new Error("Failed to complete task")) as unknown as ReturnType<typeof useMutation>;
     });
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -171,8 +169,7 @@ describe("Home Page", () => {
     } as unknown as ReturnType<typeof authKitComponents.useAuth>);
 
     vi.mocked(useMutation).mockImplementation(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return vi.fn().mockRejectedValue(new Error("Failed to create task")) as any;
+        return vi.fn().mockRejectedValue(new Error("Failed to create task")) as unknown as ReturnType<typeof useMutation>;
     });
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
🎯 **What:** Replaced `as any` type castings with `as unknown as ReturnType<...>` in `src/app/page.test.tsx` and removed unused `eslint-disable-next-line` comments.
💡 **Why:** This improves maintainability by using more precise TypeScript types instead of bypassing type checks entirely, leading to safer mocks that actually align with the hooked return types.
✅ **Verification:** Ran `pnpm test` and `pnpm lint` to ensure tests pass with the new types and no linting errors are present.
✨ **Result:** Safer type checks, no `as any` usage in test hook mocks, and zero new lint warnings or broken tests.

---
*PR created automatically by Jules for task [12748819379600490940](https://jules.google.com/task/12748819379600490940) started by @BayanBennett*