### PR TITLE
🔒 Fix incomplete input validation in createTask mutation

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -68,6 +68,24 @@ describe("tasks", () => {
   });
 
 
+  it("should throw an error when rawCapture is empty or whitespace", async () => {
+    const t = initTest();
+
+    // Setup: Create an org and user
+    await setupUserAndOrg(t, "user_empty", "org_empty");
+
+    // Action: Create a task with empty/whitespace string
+    const tWithIdentity = t.withIdentity({ tokenIdentifier: "user_empty", subject: "user_empty" });
+    const promise1 = tWithIdentity.mutation(api.functions.createTask, { rawCapture: "" });
+    const promise2 = tWithIdentity.mutation(api.functions.createTask, { rawCapture: "   " });
+    const promise3 = tWithIdentity.mutation(api.functions.createTask, { rawCapture: "\n\t" });
+
+    // Validation: Check that it throws an error
+    await expect(promise1).rejects.toThrow("rawCapture cannot be empty");
+    await expect(promise2).rejects.toThrow("rawCapture cannot be empty");
+    await expect(promise3).rejects.toThrow("rawCapture cannot be empty");
+  });
+
   it("should throw an error when rawCapture exceeds the maximum length", async () => {
     const t = initTest();
 

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -41,6 +41,10 @@ export const createTask = mutation({
     rawCapture: v.string(),
   },
   handler: async (ctx, args) => {
+    if (args.rawCapture.trim().length === 0) {
+      throw new ConvexError("rawCapture cannot be empty");
+    }
+
     if (args.rawCapture.length > 4096) {
       throw new ConvexError("rawCapture exceeds maximum length of 4096 characters");
     }


### PR DESCRIPTION
🎯 What: Prevents tasks from being created with empty or whitespace-only inputs.
⚠️ Risk: Empty task captures could cause downstream processing errors, unexpected behaviors in the UI, or lead to database pollution with meaningless records.
🛡️ Solution: Add an `args.rawCapture.trim().length === 0` validation check to the `createTask` mutation.

---
*PR created automatically by Jules for task [4263108141091523783](https://jules.google.com/task/4263108141091523783) started by @BayanBennett*